### PR TITLE
fix(meta tag) adiciona atributo de maximum-scale dentro da meta tag na master e /html/master

### DIFF
--- a/packages/agenciafmd/frontend/src/resources/views/html/master.blade.php
+++ b/packages/agenciafmd/frontend/src/resources/views/html/master.blade.php
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5.0">
 
     <title>@yield('title', '') | {{ config('app.name') }}</title>
     <meta name="description" content="@yield('description', '')">

--- a/packages/agenciafmd/frontend/src/resources/views/master.blade.php
+++ b/packages/agenciafmd/frontend/src/resources/views/master.blade.php
@@ -21,7 +21,7 @@
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5.0">
 
     <title>@yield('title', '') | {{ config('app.name') }}</title>
     <meta name="description" content="@yield('description', '')">


### PR DESCRIPTION
Como frontender, preciso ajustar o maximum-scale=1.0 para 5, pois o valor mínimo para as vezes que o usuário consegue dar zoom tem que ser 5, pois isso influencia na acessibilidade no lighthouse.