### PR TITLE
fix(variables): Remove multiplicador do padding do container

### DIFF
--- a/resources/sass/frontend/_variables.scss
+++ b/resources/sass/frontend/_variables.scss
@@ -506,7 +506,7 @@ $grid-row-columns: 6 !default;
 
 // Container padding
 
-$container-padding-x: $grid-gutter-width * .5 !default;
+$container-padding-x: $grid-gutter-width !default;
 
 
 // Components


### PR DESCRIPTION
## PR Checklist
Por favor, verifique se o seu PR cumpre os seguintes requisitos:

- [x] A mensagem de commit segue o padrão do Commit Amigão: [https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit](https://github.com/BeeTech-global/bee-stylish/blob/master/commits/README.md)
- [ ] Documentações foram adicionadas/atualizadas

## PR Type
Que tipo de mudança esse PR introduz?

<!-- Marque aquele que se aplica a esta PR usando "x". -->

- [ ] feat (nova funcionalidade)
- [ ] style (formatação geral no código. Não confundir com CSS)
- [ ] refactor (refatoração de código de produção)
- [ ] test (adicionar/refatorar testes)
- [x] fix (adivinha qual é esse)
- [ ] docs (e esse também)
- [ ] chore (atualização de tarefas ou código que não está relacionado a produção)


## Qual é o comportamento atual?
Atualmente no variables a variável $container-padding-x tem seu valor calculado a partir de "$grid-gutter-width * .5", fazendo com que o container tenha o padding incorreto causando scroll lateral.

Issue Number: N/A


## Qual é o novo comportamento?
Remove o multiplicador de 0.5 fazendo com que o padding seja calculado corretamente

## Outra informação
