### PR TITLE
feat(floating label): Adiciona transição no label do select quando efetua o preenchimento do campo

### DIFF
--- a/packages/agenciafmd/frontend/src/resources/views/html/tema.blade.php
+++ b/packages/agenciafmd/frontend/src/resources/views/html/tema.blade.php
@@ -1263,9 +1263,18 @@
                             <input type="email" class="form-control" id="floatingInput" placeholder="name@example.com">
                             <label for="floatingInput">Email address</label>
                         </div>
-                        <div class="form-floating">
+                        <div class="form-floating mb-1">
                             <input type="password" class="form-control" id="floatingPassword" placeholder="Password">
                             <label for="floatingPassword">Password</label>
+                        </div>
+                        <div class="form-floating">
+                            <select class="form-select" id="floatingSelect" aria-label="Floating label select example">
+                                <option value="" selected></option>
+                                <option value="1">One</option>
+                                <option value="2">Two</option>
+                                <option value="3">Three</option>
+                            </select>
+                            <label for="floatingSelect">Works with selects</label>
                         </div>
                     </div>
                 </form>

--- a/resources/sass/components/_floating-labels.scss
+++ b/resources/sass/components/_floating-labels.scss
@@ -1,54 +1,49 @@
-$form-floating-label-height: 100%;
-$form-floating-label-top: 0;
-$form-floating-label-left: 0;
-$form-floating-label-padding: $form-floating-padding-y $form-floating-padding-x;
-$form-floating-label-bg: none;
-
+// Not a Bootstrap standard option
 @if $enable-floating-label-over-the-line {
-  $form-floating-height: $input-height;
-  $form-floating-line-height: $input-line-height;
-  $form-floating-padding-y: $input-padding-y;
   $form-floating-input-padding-t: $input-padding-y;
   $form-floating-input-padding-b: $input-padding-y;
-  $form-floating-label-padding: 0 0.5rem;
-  $form-floating-label-height: auto;
-  $form-floating-label-top: $form-floating-padding-y;
-  $form-floating-label-left: $input-padding-x - 0.5rem;
-  $form-floating-label-opacity: 1;
-  $form-floating-label-bg: $input-bg;
-  $form-floating-label-transform: scale(.85) translateY(-1rem) translateX(.15rem);
+  $form-floating-padding-y: $input-padding-y;
+  $form-floating-height: $input-height;
+  $form-floating-line-height: $input-line-height;
+  $form-floating-label-transform: scale(.85) translateY(calc(-.5 * #{$input-height})) translateX(.15rem);
   $form-floating-transition: $transition-base;
 }
 
 .form-floating {
+  position: relative;
+
   > .form-control,
-  > .form-control:focus,
-  > .form-control:not(:placeholder-shown),
+  > .form-control-plaintext,
   > .form-select {
     height: $form-floating-height;
-
-    ~ label {
-      color: $input-color;
-    }
-  }
-
-  > textarea.form-control {
-    height: calc(#{$input-height} * 3);
+    min-height: $form-floating-height;
+    line-height: $form-floating-line-height;
   }
 
   > label {
-    top: $form-floating-label-top;
-    left: $form-floating-label-left;
-    height: $form-floating-label-height;
-    padding: $form-floating-label-padding;
-    background: $form-floating-label-bg;
-    width: auto;
-    margin: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 2;
+    height: 100%; // allow textareas
+    padding: $form-floating-padding-y $form-floating-padding-x;
+    overflow: hidden;
+    text-align: start;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+    border: $input-border-width solid transparent; // Required for aligning label's text with the input as it affects inner box model
+    transform-origin: 0 0;
+    @include transition($form-floating-transition);
   }
 
-  // stylelint-disable no-duplicate-selectors
-  > .form-control {
+  > .form-control,
+  > .form-control-plaintext {
     padding: $form-floating-padding-y $form-floating-padding-x;
+
+    &::placeholder {
+      color: transparent;
+    }
 
     &:focus,
     &:not(:placeholder-shown) {
@@ -66,13 +61,60 @@ $form-floating-label-bg: none;
   > .form-select {
     padding-top: $form-floating-input-padding-t;
     padding-bottom: $form-floating-input-padding-b;
-    transition: .125s;
+  }
 
-    &:required:valid, &:has(option:not(:empty):checked) {
+  > .form-control:focus,
+  > .form-control:not(:placeholder-shown),
+  > .form-control-plaintext,
+  > .form-select {
+    ~ label {
+      color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
+      transform: $form-floating-label-transform;
+
+      &::after {
+        position: absolute;
+        inset: $form-floating-padding-y ($form-floating-padding-x * .5);
+        z-index: -1;
+        height: $form-floating-label-height;
+        content: "";
+        background-color: $input-bg;
+        @include border-radius($input-border-radius);
+      }
+    }
+  }
+
+  // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
+  > .form-control:-webkit-autofill {
+    ~ label {
+      color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
+      transform: $form-floating-label-transform;
+    }
+  }
+
+  > .form-control-plaintext {
+    ~ label {
+      border-width: $input-border-width 0; // Required to properly position label text - as explained above
+    }
+  }
+
+  > :disabled ~ label {
+    color: $form-floating-label-disabled-color;
+
+    &::after {
+      background-color: $input-disabled-bg;
+    }
+  }
+
+  // Not a Bootstrap standard option
+  > .form-select {
+    @include transition($form-floating-transition);
+
+    &:required:valid,
+    &:has(option:not(:empty):checked) {
       ~ label {
         top: 0;
-        opacity: $form-floating-label-opacity;
         transform: $form-floating-label-transform;
+        color: rgba(var(--#{$prefix}body-color-rgb), #{$form-floating-label-opacity});
       }
     }
 
@@ -80,26 +122,7 @@ $form-floating-label-bg: none;
       opacity: 1;
       transform: none;
       transition: .125s ease-in;
+      color: inherit;
     }
   }
-
-  > .form-control:focus,
-  > .form-control:not(:placeholder-shown) {
-    ~ label {
-      top: 0;
-      opacity: $form-floating-label-opacity;
-      transform: $form-floating-label-transform;
-    }
-  }
-
-  // Duplicated because `:-webkit-autofill` invalidates other selectors when grouped
-  > .form-control:-webkit-autofill {
-    ~ label {
-      top: 0;
-      opacity: $form-floating-label-opacity;
-      transform: $form-floating-label-transform;
-    }
-  }
-
-  // stylelint-enable no-duplicate-selectors
 }

--- a/resources/sass/components/_floating-labels.scss
+++ b/resources/sass/components/_floating-labels.scss
@@ -1,3 +1,4 @@
+$form-floating-label-height: 100%;
 $form-floating-label-top: 0;
 $form-floating-label-left: 0;
 $form-floating-label-padding: $form-floating-padding-y $form-floating-padding-x;
@@ -10,6 +11,7 @@ $form-floating-label-bg: none;
   $form-floating-input-padding-t: $input-padding-y;
   $form-floating-input-padding-b: $input-padding-y;
   $form-floating-label-padding: 0 0.5rem;
+  $form-floating-label-height: auto;
   $form-floating-label-top: $form-floating-padding-y;
   $form-floating-label-left: $input-padding-x - 0.5rem;
   $form-floating-label-opacity: 1;
@@ -20,8 +22,14 @@ $form-floating-label-bg: none;
 
 .form-floating {
   > .form-control,
+  > .form-control:focus,
+  > .form-control:not(:placeholder-shown),
   > .form-select {
     height: $form-floating-height;
+
+    ~ label {
+      color: $input-color;
+    }
   }
 
   > textarea.form-control {
@@ -58,11 +66,25 @@ $form-floating-label-bg: none;
   > .form-select {
     padding-top: $form-floating-input-padding-t;
     padding-bottom: $form-floating-input-padding-b;
+    transition: .125s;
+
+    &:required:valid, &:has(option:not(:empty):checked) {
+      ~ label {
+        top: 0;
+        opacity: $form-floating-label-opacity;
+        transform: $form-floating-label-transform;
+      }
+    }
+
+    ~ label {
+      opacity: 1;
+      transform: none;
+      transition: .125s ease-in;
+    }
   }
 
   > .form-control:focus,
-  > .form-control:not(:placeholder-shown),
-  > .form-select {
+  > .form-control:not(:placeholder-shown) {
     ~ label {
       top: 0;
       opacity: $form-floating-label-opacity;

--- a/resources/sass/frontend/_variables.scss
+++ b/resources/sass/frontend/_variables.scss
@@ -1113,7 +1113,7 @@ $form-floating-padding-x:               $input-padding-x !default;
 $form-floating-padding-y:               1rem !default;
 $form-floating-input-padding-t:         1.625rem !default;
 $form-floating-input-padding-b:         .625rem !default;
-$form-floating-label-height:            auto !default;
+$form-floating-label-height:            1.5em !default;
 $form-floating-label-opacity:           .65 !default;
 $form-floating-label-transform:         scale(.85) translateY(-.5rem) translateX(.15rem) !default;
 $form-floating-label-disabled-color:    $gray-600 !default;


### PR DESCRIPTION
## PR Checklist
Por favor, verifique se o seu PR cumpre os seguintes requisitos:

- [x] A mensagem de commit segue o padrão do Commit Amigão: [https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit](https://github.com/BeeTech-global/bee-stylish/blob/master/commits/README.md)
- [ ] Documentações foram adicionadas/atualizadas

## PR Type
Que tipo de mudança esse PR introduz?

<!-- Marque aquele que se aplica a esta PR usando "x". -->

- [x] feat (nova funcionalidade)
- [ ] style (formatação geral no código. Não confundir com CSS)
- [ ] refactor (refatoração de código de produção)
- [ ] test (adicionar/refatorar testes)
- [ ] fix (adivinha qual é esse)
- [ ] docs (e esse também)
- [ ] chore (atualização de tarefas ou código que não está relacionado a produção)


## Qual é o comportamento atual?
Atualmente o label do floating-label possui uma animação conforme a interação com o campo, acontece que no select ele fica configurado para sempre ficar ao topo, independente de qual opção escolhe. Conforme [Documentação](https://getbootstrap.com/docs/5.3/forms/floating-labels/#selects)

Issue Number: N/A


## Qual é o novo comportamento?
Implementado funcionalidade que movimenta o label do select [Preview](https://unicosfeirao.fmd.dev/html/tema)

## Outra informação
