### PR TITLE
feat(estilização): ajusta propriedade height de classe de img-full-page

### DIFF
--- a/resources/sass/components/_images.scss
+++ b/resources/sass/components/_images.scss
@@ -29,7 +29,7 @@ picture.ratio {
 
     &-full-page {
       width: 100vw;
-      height: 100vh;
+      height: 100dvh;
       object-fit: cover;
     }
   }


### PR DESCRIPTION
## PR Checklist
Por favor, verifique se o seu PR cumpre os seguintes requisitos:

- [x] A mensagem de commit segue o padrão do Commit Amigão: [https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit](https://github.com/BeeTech-global/bee-stylish/blob/master/commits/README.md)
- [ ] Documentações foram adicionadas/atualizadas

## PR Type
Que tipo de mudança esse PR introduz?

<!-- Marque aquele que se aplica a esta PR usando "x". -->

- [x] feat (nova funcionalidade)
- [ ] style (formatação geral no código. Não confundir com CSS)
- [ ] refactor (refatoração de código de produção)
- [ ] test (adicionar/refatorar testes)
- [ ] fix (adivinha qual é esse)
- [ ] docs (e esse também)
- [ ] chore (atualização de tarefas ou código que não está relacionado a produção)


## Qual é o comportamento atual?
Atualmente na classe de estilo `img-full-page` temos a propriedade de height com o valor de 100vh. Que na qual oferece o comportamento de full window quando utilizamos ela e funciona bem. Porém quando vamos para navegadores mobile o banner fica sobreposto pela UI do navegador, dando a impressão de "mal funcionamento" pois o banner estoura o "100vh" do device.

Issue Number: N/A


## Qual é o novo comportamento?
Altera a propriedade `100vh` para `100dvh`. Com isso a classe full-page fica dinâmica e passa a ter o comportamento correto em devices mobile.

## Outra informação
