### PR TITLE
fix(glightbox videos): Ajusta estrutura da classe de ic-play para prvenir problemas no firefox e safari, e para melhorar legibilidade

### DIFF
--- a/packages/agenciafmd/frontend/resources/views/components/glightbox/player-embed.blade.php
+++ b/packages/agenciafmd/frontend/resources/views/components/glightbox/player-embed.blade.php
@@ -39,10 +39,10 @@
                     data-plyr-provider="{{ $provider }}"
                     data-plyr-embed-id="{{ $link }}"
                     id="player-{{ $id }}"
-                    class="stretched-link {{ $iconClass }} js-player-embed-link ic-play"
+                    class="stretched-link {{ $iconClass }} js-player-embed-link ic-play-container"
                     aria-label="Clique para assistir o vídeo"
                     title="Ver vídeo">
-    <x-frontend-icon class="vstack align-items-center justify-content-center rounded-circle icon position-absolute top-50 start-50 translate-middle z-1"
+    <x-frontend-icon class="vstack align-items-center justify-content-center rounded-circle ic-play position-absolute top-50 start-50 translate-middle z-1"
                      name="ic-ui-play"/>
   </x-frontend::link>
 

--- a/packages/agenciafmd/frontend/resources/views/components/glightbox/video.blade.php
+++ b/packages/agenciafmd/frontend/resources/views/components/glightbox/video.blade.php
@@ -11,10 +11,10 @@
                   data-description="{{ $description }}"
                   title="{{ $title ? $title : $description }}"
                   aria-label="Link: {{ $title ? $title : $description }}"
-                  {{ $attributes->merge(['class' => 'position-relative glightbox ic-play']) }}>
+                  {{ $attributes->merge(['class' => 'position-relative glightbox ic-play-container']) }}>
   {{ $slot }}
 
-  <x-frontend-icon class="vstack align-items-center justify-content-center rounded-circle icon position-absolute top-50 start-50 translate-middle z-1"
+  <x-frontend-icon class="vstack align-items-center justify-content-center rounded-circle ic-play position-absolute top-50 start-50 translate-middle z-1"
                      name="ic-ui-play"/>
 </x-frontend::link>
 

--- a/resources/scss/components/_icons.scss
+++ b/resources/scss/components/_icons.scss
@@ -73,24 +73,26 @@ $icon-xl: 4rem !default; //64
 
   &-play {
 
-    .icon {
-      color: $white;
-      background: rgba($primary, $opacity-level-semi-opaque);
-      transition: $transition-base;
-      width: $icon-md;
-      height: $icon-md;
+    color: $white;
+    background: rgba($primary, $opacity-level-semi-opaque);
+    transition: $transition-base;
+    width: $icon-md;
+    height: $icon-md;
 
-      @include media-breakpoint-up(xl) {
-        width: $icon-md * 1.5;
-        height: $icon-md * 1.5;
-      }
+    @include media-breakpoint-up(xl) {
+      width: $icon-md * 1.5;
+      height: $icon-md * 1.5;
     }
 
-    @include media-breakpoint-up(md) {
-      &:hover {
-        .icon {
-          box-shadow: $box-shadow;
-          background: rgba($primary, $opacity-level-intense);
+    &-container {
+      display: block;
+
+      @include media-breakpoint-up(md) {
+        &:hover {
+          .ic-play {
+            box-shadow: $box-shadow;
+            background: rgba($primary, $opacity-level-intense);
+          }
         }
       }
     }


### PR DESCRIPTION
## PR Checklist
Por favor, verifique se o seu PR cumpre os seguintes requisitos:

- [ x] A mensagem de commit segue o padrão do Commit Amigão: [https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit](https://github.com/BeeTech-global/bee-stylish/blob/master/commits/README.md)
- [ ] Documentações foram adicionadas/atualizadas

## PR Type
Que tipo de mudança esse PR introduz?

<!-- Marque aquele que se aplica a esta PR usando "x". -->

- [ ] feat (nova funcionalidade)
- [ ] style (formatação geral no código. Não confundir com CSS)
- [ ] refactor (refatoração de código de produção)
- [ ] test (adicionar/refatorar testes)
- [ x] fix (adivinha qual é esse)
- [ ] docs (e esse também)
- [ ] chore (atualização de tarefas ou código que não está relacionado a produção)


## Qual é o comportamento atual?

Atualmente o componente de video de glightbox tem um problema onde no safari e no Firefox, o ícone de play não fica alinhado ao centro

Issue Number: N/A


## Qual é o novo comportamento?

Com o novo comportamento, o icone de play fica alinhado corretamente ao centro da imagem

## Outra informação
